### PR TITLE
TOOC-71 adds js-formmailer for all contact forms

### DIFF
--- a/en/about-us/contact/index.html
+++ b/en/about-us/contact/index.html
@@ -29,6 +29,7 @@
 <script type='text/javascript' src='../../../wp-includes/js/jquery/jquery.js?ver=1.11.0'></script>
 <script type='text/javascript' src='../../../wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1'></script>
 <script type='text/javascript' src='../../../wp-content/plugins/revslider/rs-plugin/js/jquery.themepunch.revolution.min-ver=3.9.3.js'></script>
+<script type='text/javascript' src='../../../wp-content/themes/Toocan/js/formmailer.js'></script>
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="../../../xmlrpc.php-rsd.xml" />
 <link rel="wlwmanifest" type="application/wlwmanifest+xml" href="../../../wp-includes/wlwmanifest.xml" /> 
 <meta name="generator" content="WordPress 3.9.3" />
@@ -1015,7 +1016,9 @@ color: #666;
 				});
 			</script>
 <p>&nbsp;</p>
-<form class="g-form" action="" method="post"><input type="hidden" name="action" value="contact">
+<form class="g-form formmailer" action="" method="post">
+	<input type="hidden" name="action" value="contact">
+	<input type="hidden" name="language" value="en">
 			<div class="g-form-group">
 				<div class="g-form-group-rows"><div class="g-form-row">
 						<div class="g-form-row-label">

--- a/en/get-started/index.html
+++ b/en/get-started/index.html
@@ -28,6 +28,7 @@
 <script type='text/javascript' src='../../wp-includes/js/jquery/jquery.js?ver=1.11.0'></script>
 <script type='text/javascript' src='../../wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1'></script>
 <script type='text/javascript' src='../../wp-content/plugins/revslider/rs-plugin/js/jquery.themepunch.revolution.min-ver=3.9.3.js'></script>
+<script type='text/javascript' src='../../wp-content/themes/Toocan/js/formmailer.js'></script>
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="../../xmlrpc.php-rsd.xml" />
 <link rel="wlwmanifest" type="application/wlwmanifest+xml" href="../../wp-includes/wlwmanifest.xml" /> 
 <meta name="generator" content="WordPress 3.9.3" />
@@ -1000,7 +1001,10 @@ color: #666;
 
 
 	<div class="l-submain"><div class="l-submain-h g-html i-cf"><p><!--:de-->You want to <strong>start immediately</strong> with a Toocan product or get <strong>further insights</strong>? Then contact us here:</p>
-<form class="g-form" action="" method="post"><input type="hidden" name="action" value="contact">
+<form class="g-form formmailer" action="" method="post">
+	<input type="hidden" name="action" value="contact">
+	<input type="hidden" name="language" value="en">
+
 			<div class="g-form-group">
 				<div class="g-form-group-rows"><div class="g-form-row">
 						<div class="g-form-row-label">

--- a/jetzt-starten/index.html
+++ b/jetzt-starten/index.html
@@ -28,6 +28,7 @@
 <script type='text/javascript' src='../wp-includes/js/jquery/jquery.js?ver=1.11.0'></script>
 <script type='text/javascript' src='../wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1'></script>
 <script type='text/javascript' src='../wp-content/plugins/revslider/rs-plugin/js/jquery.themepunch.revolution.min-ver=3.9.3.js'></script>
+<script type='text/javascript' src='../wp-content/themes/Toocan/js/formmailer.js'></script>
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="../xmlrpc.php-rsd.xml" />
 <link rel="wlwmanifest" type="application/wlwmanifest+xml" href="../wp-includes/wlwmanifest.xml" /> 
 <meta name="generator" content="WordPress 3.9.3" />
@@ -1004,7 +1005,9 @@ color: #666;
 
 
 	<div class="l-submain"><div class="l-submain-h g-html i-cf"><p><!--:de-->Sie möchten sofort mit einem Toocan-Produkt loslegen oder wollen weitere Einblicke? Dann schreiben Sie uns:</p>
-<form class="g-form" action="" method="post"><input type="hidden" name="action" value="contact">
+<form class="g-form formmailer" action="" method="post">
+	<input type="hidden" name="action" value="contact">
+	<input type="hidden" name="language" value="de">
 			<div class="g-form-group">
 				<div class="g-form-group-rows"><div class="g-form-row">
 						<div class="g-form-row-label">

--- a/jetzt-starten/index.html
+++ b/jetzt-starten/index.html
@@ -1011,7 +1011,7 @@ color: #666;
 			<div class="g-form-group">
 				<div class="g-form-group-rows"><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="contact_name">Your name *</label>
+							<label class="g-form-row-label-h" for="contact_name">Ihr Name *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1021,7 +1021,7 @@ color: #666;
 						
 					</div><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="contact_email">Your Email *</label>
+							<label class="g-form-row-label-h" for="contact_email">Ihre E-Mail-Adresse *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1031,7 +1031,7 @@ color: #666;
 						
 					</div><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="contact_phone">Your Phone *</label>
+							<label class="g-form-row-label-h" for="contact_phone">Ihre Telefonnummer *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1041,7 +1041,7 @@ color: #666;
 						
 					</div><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="input1x3">Your Message *</label>
+							<label class="g-form-row-label-h" for="input1x3">Ihre Nachricht *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1052,7 +1052,7 @@ color: #666;
 					</div><div class="g-form-row">
 						<div class="g-form-row-label"></div>
 						<div class="g-form-row-field">
-							<button class="g-btn type_primary">Send Message</button>
+							<button class="g-btn type_primary">Nachricht versenden</button>
 						</div>
 					</div>
 				</div>

--- a/ueber-uns/kontakt/index.html
+++ b/ueber-uns/kontakt/index.html
@@ -28,6 +28,7 @@
 <script type='text/javascript' src='../../wp-includes/js/jquery/jquery.js?ver=1.11.0'></script>
 <script type='text/javascript' src='../../wp-includes/js/jquery/jquery-migrate.min.js?ver=1.2.1'></script>
 <script type='text/javascript' src='../../wp-content/plugins/revslider/rs-plugin/js/jquery.themepunch.revolution.min-ver=3.9.3.js'></script>
+<script type='text/javascript' src='../../wp-content/themes/Toocan/js/formmailer.js'></script>
 <link rel="EditURI" type="application/rsd+xml" title="RSD" href="../../xmlrpc.php-rsd.xml" />
 <link rel="wlwmanifest" type="application/wlwmanifest+xml" href="../../wp-includes/wlwmanifest.xml" /> 
 <meta name="generator" content="WordPress 3.9.3" />
@@ -1018,7 +1019,9 @@ color: #666;
 				});
 			</script>
 <p>&nbsp;</p>
-<form class="g-form" action="" method="post"><input type="hidden" name="action" value="contact">
+<form class="g-form formmailer" action="" method="post">
+	<input type="hidden" name="action" value="contact">
+	<input type="hidden" name="language" value="de">
 			<div class="g-form-group">
 				<div class="g-form-group-rows"><div class="g-form-row">
 						<div class="g-form-row-label">

--- a/ueber-uns/kontakt/index.html
+++ b/ueber-uns/kontakt/index.html
@@ -1025,7 +1025,7 @@ color: #666;
 			<div class="g-form-group">
 				<div class="g-form-group-rows"><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="contact_name">Your name *</label>
+							<label class="g-form-row-label-h" for="contact_name">Ihr Name *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1035,7 +1035,7 @@ color: #666;
 						
 					</div><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="contact_email">Your Email *</label>
+							<label class="g-form-row-label-h" for="contact_email">Ihre E-Mail-Adresse *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1045,7 +1045,7 @@ color: #666;
 						
 					</div><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="contact_phone">Your Phone *</label>
+							<label class="g-form-row-label-h" for="contact_phone">Ihre Telefonnummer *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1055,7 +1055,7 @@ color: #666;
 						
 					</div><div class="g-form-row">
 						<div class="g-form-row-label">
-							<label class="g-form-row-label-h" for="input1x3">Your Message *</label>
+							<label class="g-form-row-label-h" for="input1x3">Ihre Nachricht *</label>
 						</div>
 						<div class="g-form-row-field">
 							<div class="g-input">
@@ -1066,7 +1066,7 @@ color: #666;
 					</div><div class="g-form-row">
 						<div class="g-form-row-label"></div>
 						<div class="g-form-row-field">
-							<button class="g-btn type_primary">Send Message</button>
+							<button class="g-btn type_primary">Nachricht versenden</button>
 						</div>
 					</div>
 				</div>

--- a/wp-content/themes/Toocan/js/formmailer.js
+++ b/wp-content/themes/Toocan/js/formmailer.js
@@ -15,20 +15,23 @@ jQuery(function() {
 
     var
       // configuration
-      recipients = ['info@toocan.biz'],
-      subject = 'Contact Request toocan.biz '
+      recipients = ['info@toocan.biz']
       ;
     
-    // aggregate all fields from the form and add the values to the mail’s text
     var
       $form = jQuery(e.currentTarget),
-      $fields = $form.find('textarea,input,select'),
-      text = ''
+      text = 
+        $form.find('#contact_message').val() + "\r\n\r\n" +
+        "Name: " + $form.find('#contact_name').val() + "\r\n" +
+        "E-Mail: " + $form.find('#contact_email').val() + "\r\n" +
+        "Telefon: " + $form.find('#contact_phone').val()
       ;
-    $fields.each(function(index, input) {
-      var $input = jQuery(input);
-      text += "# " + $input.attr('name') + "\r\n" + $input.val().trim() + "\r\n\r\n";
-    });
+
+    // set subject language dependend
+    var subject = 'Contact Request toocan.biz';
+    if ($form.find('[name="language"]').val() === 'de') {
+      subject = 'Kontaktanfrage von toocan.biz';
+    }
 
     // compose the url 
     var url = "mailto:" + recipients.join(',') + "?" + 

--- a/wp-content/themes/Toocan/js/formmailer.js
+++ b/wp-content/themes/Toocan/js/formmailer.js
@@ -1,0 +1,43 @@
+/**
+ * Simple JS-Formmailer
+ *
+ * This is a simple implementation of a formmailer which serializes all form
+ * fields to a string and opens up a `mailto://` link which then opens the
+ * default mail handler on the client’s OS with prefilled subject, recipient
+ * and text.
+ *
+ * Just add the `.formmailer` class to the form and include this script.
+ */
+jQuery(function() {
+  jQuery('form.formmailer').on('submit', function(e) {
+    // stop submitting
+    e.preventDefault();
+
+    var
+      // configuration
+      recipients = ['info@toocan.biz'],
+      subject = 'Contact Request toocan.biz '
+      ;
+    
+    // aggregate all fields from the form and add the values to the mail’s text
+    var
+      $form = jQuery(e.currentTarget),
+      $fields = $form.find('textarea,input,select'),
+      text = ''
+      ;
+    $fields.each(function(index, input) {
+      var $input = jQuery(input);
+      text += "# " + $input.attr('name') + "\r\n" + $input.val().trim() + "\r\n\r\n";
+    });
+
+    // compose the url 
+    var url = "mailto:" + recipients.join(',') + "?" + 
+      "subject=" + escape(subject) + "&" + 
+      "body=" + escape(text);
+
+    // open mailto schema handler
+    document.location.href = url;
+
+    return true;
+  });
+});


### PR DESCRIPTION
Simple implementation of a javascript formmailer script which depends on jQuery. If a form with the `.formmailer` class gets submitted all form fields (input, select, textarea) get’s serialized into a string which is used to open the client’s default `mailto://` schema handler (e-mail app) with prefilled text and subject.

Script got included into all contact forms. I’ve added also a hidden `language` field in all forms to pass over the language as well.
